### PR TITLE
[플레이어(보스)] 시간 -1초, UI 연결 문제 해결

### DIFF
--- a/Assets/ljk/Script/GameOver.cs
+++ b/Assets/ljk/Script/GameOver.cs
@@ -5,25 +5,20 @@ using UnityEngine.SceneManagement;
 
 public class GameOver : MonoBehaviour
 {
-    public GameObject Player;
-    private Scene Seen; //ÇöÀç ¾À ÀúÀåÇÒ º¯¼ö
+    private Scene Seen; //ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½
 
-    // Start is called before the first frame update
     void Start()
     {
         Seen = SceneManager.GetActiveScene();
-    }
-
-    void Awake()
-    {
-        Player.SetActive(false);
     }
     // Update is called once per frame
     void Update()
     {
         if (Input.GetKeyDown(KeyCode.Space))
         {
-            SceneManager.LoadScene(Seen.buildIndex); //ÇöÀç¾À ´Ù½Ã ½ÃÀÛÇÏ±â
+            SceneManager.LoadScene(Seen.buildIndex); //ï¿½ï¿½ï¿½ï¿½ï¿½ ï¿½Ù½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½Ï±ï¿½
         }
     }
+
+
 }

--- a/Assets/sjh/Scripts/BattleManager.cs
+++ b/Assets/sjh/Scripts/BattleManager.cs
@@ -47,6 +47,8 @@ public class BattleManager : MonoBehaviour
     private Winner winner; // 열거형으로 변경
 
     public GameObject pauseUI;
+    public GameObject gameOverUI;
+    public GameObject gameClearUI;
     private bool isGamePaused;
 
     void Awake()
@@ -63,6 +65,8 @@ public class BattleManager : MonoBehaviour
     {
         player = GameObject.FindWithTag("Player");
         pauseUI.SetActive(false);
+        gameOverUI.SetActive(false);
+        gameClearUI.SetActive(false);
         playerController = player.GetComponent<PlayerController>();
         if (isBossScene) 
         {
@@ -95,10 +99,19 @@ public class BattleManager : MonoBehaviour
 
     void Decision() // 승자 판정
     {
-        if (!isBossScene) return; 
-
         if (playerController.playerHP <= 0)
         {
+            winner = Winner.Monster;
+            GameOver();
+            ChangeState(State.KO);
+        }
+
+        if (!isBossScene) return; 
+
+        if (bossController.bossHP <= 0)
+        {
+            winner = Winner.Player;
+            GameOver();
             ChangeState(State.KO);
         }
 
@@ -108,19 +121,17 @@ public class BattleManager : MonoBehaviour
             GameOver();
             ChangeState(State.TKO);
         }
-
-        
     }
 
     void GameOver()
     {
         if (winner == Winner.Monster)
         {
-            Debug.Log("Monster Wins! Game Over." + curState);
+            gameOverUI.SetActive(true);
         }
         else if (winner == Winner.Player)
         {
-            Debug.Log("Player Wins! Congratulations!" + curState);
+            gameClearUI.SetActive(true);
         }
     }
 
@@ -128,16 +139,16 @@ public class BattleManager : MonoBehaviour
     {
         if (!isBossScene) return;
 
-        int previousTime = Mathf.FloorToInt(limitTime);
         limitTime -= Time.deltaTime;
         int currentTime = Mathf.FloorToInt(limitTime);
         timeText.text = currentTime.ToString();
-        if (limitTime <= 0)
+        if (currentTime <= 0)
         {
             limitTime = 0;
             Debug.Log("Time is Over.");
             Decision();
         }
+        
     }
 
 
@@ -147,7 +158,7 @@ public class BattleManager : MonoBehaviour
         switch(curState)
         {
              case State.Ready:
-                PauseUIDelay();
+    
                 if (Input.GetKeyDown(KeyCode.Escape) && isGamePaused)
                 {
                     Time.timeScale = 1;
@@ -164,7 +175,6 @@ public class BattleManager : MonoBehaviour
                     Debug.Log("Pause Screen Opened");
                     pauseUI.SetActive(true);
                     Time.timeScale = 0;
-                    PauseUIDelay();
                     ChangeState(State.Ready);
                     
                 }
@@ -194,10 +204,6 @@ public class BattleManager : MonoBehaviour
         }
     }
 
-    private IEnumerator PauseUIDelay()
-    {
-        yield return new WaitForSeconds(1f);
-    }
 
 
 


### PR DESCRIPTION
# 수정사항

지난 회의 때 확인한 시간이 -1초까지 내려가는 문제, GameOverUI가 안 뜨는 문제와 추가적으로 발견한 GameOverUI 와 GameClearUI의 문제를 해결


# 적용사항

각 씬의 BattleManager 에 GameOverUI, GameClearUI 할당