### PR TITLE
보스씬에서 쓸 카메라 스크립트 작성

### DIFF
--- a/Assets/Scenes/LJK/BossBattle_tuto.unity
+++ b/Assets/Scenes/LJK/BossBattle_tuto.unity
@@ -372,7 +372,7 @@ GameObject:
   - component: {fileID: 661350375}
   m_Layer: 0
   m_Name: Boss(NoScript)
-  m_TagString: Untagged
+  m_TagString: Monster
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -643,6 +643,7 @@ GameObject:
   - component: {fileID: 732767167}
   - component: {fileID: 732767166}
   - component: {fileID: 732767165}
+  - component: {fileID: 732767168}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -724,6 +725,18 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &732767168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 732767164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: acaff4a8b0bb5b54baaf34125995bed2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!224 &816907547 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1431804040297667099, guid: 1fa17a4028383aa46aa1591519635078, type: 3}
@@ -1681,7 +1694,7 @@ GameObject:
   - component: {fileID: 1389186815}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2094,7 +2107,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a68160a9f61a955448cf6e3b6c0cde3f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Player: {fileID: 1389186810}
 --- !u!114 &1449132133
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2287,7 +2299,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a68160a9f61a955448cf6e3b6c0cde3f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Player: {fileID: 1389186810}
 --- !u!114 &1661178311
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/ljk/Script/Camera_Boss.cs
+++ b/Assets/ljk/Script/Camera_Boss.cs
@@ -1,20 +1,51 @@
 using System.Collections;
 using System.Collections.Generic;
+using TMPro;
+using Unity.VisualScripting;
 using UnityEngine;
+
+
 
 
 public class Camera_Boss : MonoBehaviour
 {
-    GameObject camera;
+    Transform Player_tr;
+    Transform Boss_tr;
+    Transform Cam_tr;
+
+    float LastX = 0;
+    float MidPoint;
+
+    Transform LastPosition;
+    Transform TargetPosition;
     // Start is called before the first frame update
     void Start()
     {
-        
+        Player_tr = GameObject.FindGameObjectWithTag("Player").GetComponent<Transform>();
+        Boss_tr = GameObject.FindGameObjectWithTag("Monster").GetComponent<Transform>();
+        Cam_tr = GetComponent<Transform>();
+
+        //CameraMove();
     }
 
     // Update is called once per frame
-    void Update()
+    private void LateUpdate()
     {
-        
+        if (-5 < LastX && LastX < 5)
+        {
+            MidPoint = (Player_tr.transform.position.x + Boss_tr.transform.position.x) / 2;
+            Cam_tr.position = new Vector3(Mathf.Lerp(LastX, MidPoint, 0.5f), 0, -10);
+            LastX = Cam_tr.position.x;
+        }
+        if ( LastX < -5)
+        {
+            Cam_tr.position = new Vector3(-5, 0, -10);
+            LastX = -4.9f;
+        }
+        if  ( LastX > 5)
+        {
+            Cam_tr.position = new Vector3(5, 0, -10);
+            LastX = 4.9f;
+        }
     }
 }


### PR DESCRIPTION
보스배틀씬에서 카메라 스크립트 작성함
(보스와 싸우는 씬에서)Hierachy - Main Camera - Inspector - Addcomponent - Camera_Boss 스크립트 검색해서 추가하기
*보스의 태그가 Monster, 플레이어의 태그가 Player인 상태에서 작동함

**주저리 : 원래 카메라를 Update를 사용해서 기계적으로 따라가게 하지 않고, 카메라가 별로 안 움직여도 되는 상황 = 플레이어와 보스가 중앙에 몰려 있는 경우, 카메라를 일정 시간마다 움직이게 하려고 했는데, 카메라가 순간이동하지 않고 천천히 부드럽게 이동하는 한편으로 플레이어와 보스가 구석에 갔을 때는 카메라가 Update에서 다루는 것처럼 실시간으로 계속 따라가게 하려 했는데...시간만 날렸다